### PR TITLE
Build, evaluate and use multi-output models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # MIDA-video-analysis
 Computer vision in television
 
-## Run on Apple M1
+## Install on Apple M1
+
+Because the M1 chipset has an architecture based on ARM instead of x86_64,
+we cannot use Python and Tensorflow from the default channels.
 
 In a Terminal, run `conda env create -f environment_m1.yml -n mida_video`
 to create a conda environment with basic dependencies for running the scripts
@@ -11,3 +14,73 @@ Afterwards, run `conda activate mida_video` to activate the environment.
 If you want more manual control, install Tensorflow following instructions at
 <https://developer.apple.com/metal/tensorflow-plugin/>.
 Then install the other dependencies listed in `environment_m1.yml`.
+
+## Usage
+
+The provided scripts help us train, evaluate and use computer-vision models
+based on Tensorflow and Keras.
+
+### Train a model
+
+To train a model, we need images with labels, and a name for the model.
+We expect images to be in subdirectories of a given directory.
+The filenames and corresponding labels should be in a CSV file.
+Filenames must be in a column `filename` and must be relative to the given
+directory.
+Names of columns with (numeric 0 or 1) labels must end in `_visible`.
+
+Minimal example of a labels file:
+
+
+| filename      | pentagram_visible | star_visible |
+|---------------|-------------------|--------------|
+| image001.jpg  | 1                 | 0            |
+| image002.jpg  | 1                 | 1            |
+| image003.jpg  | 0                 | 1            |
+| image004.jpg  | 0                 | 0            |
+
+A model trained on these images and labels will have two outputs: `pentagram`
+and `star`.
+
+To train a model, run:
+
+```console
+$ python build_multi_hot_model.py image_dir labels.csv output_model_dir
+```
+
+In this command:
+
+- `image_dir` is the directory that contains subdirectories with the images;
+- `labels.csv` is the CSV file holding the filename and label(s) for each image;
+- `output_model_dir` is the name of the model and the directory that it will
+  be saved to.
+
+### Evaluate a model
+
+To evaluate a model, run:
+
+```console
+$ python eval_multi_hot_model.py model_dir image_dir labels.csv results.csv
+```
+
+In this command:
+
+- `model_dir` is the directory that contains the model;
+- `image_dir` is the directory that contains subdirectories with the images;
+- `labels.csv` is the CSV file holding the filename and label(s) for each
+  image, which should be structured the same as the file used for training;
+- `results.csv` is a filename that the summary of predictions will be in.
+
+### Use a model for making predictions
+
+To make predictions using a model, run:
+
+```console
+$ python predict_images.py model_dir image_dir predictions.csv
+```
+
+In this command:
+
+- `model_dir` is the directory that contains the model;
+- `image_dir` is the directory that contains subdirectories with the images;
+- `predictions.csv` is the filename in which predictions will be saved.

--- a/build_multi_hot_model.py
+++ b/build_multi_hot_model.py
@@ -7,6 +7,7 @@ import pandas as pd
 from tensorflow import keras
 from tensorflow.keras import layers
 import sys
+import datetime
 
 
 image_directory = sys.argv[1]
@@ -21,17 +22,15 @@ metadata = pd.read_csv(csv_filename)
 train_datagen = keras.preprocessing.image.ImageDataGenerator(
     # rescale=1./255,
     rotation_range=36,
-    shear_range=0.2,
-    zoom_range=0.2,
     horizontal_flip=True,
-    validation_split=0.2)
+    validation_split=0.3)
 
 train_generator = train_datagen.flow_from_dataframe(
     dataframe=metadata,
     directory=image_directory,
-    x_col='',
-    y_col=[''],
-    weight_col='',
+    x_col='filename',
+    y_col=['pentagram_visible', 'star_visible'],
+    weight_col=None,
     target_size=(150, 150),
     color_mode='rgb',
     class_mode='raw',
@@ -43,14 +42,14 @@ train_generator = train_datagen.flow_from_dataframe(
 
 validation_datagen = keras.preprocessing.image.ImageDataGenerator(
     # rescale=1./255,
-    validation_split=0.2)
+    validation_split=0.3)
 
 validation_generator = validation_datagen.flow_from_dataframe(
     dataframe=metadata,
     directory=image_directory,
-    x_col='',
-    y_col=[''],
-    weight_col='',
+    x_col='filename',
+    y_col=['pentagram_visible', 'star_visible'],
+    weight_col=None,
     target_size=(150, 150),
     color_mode='rgb',
     class_mode='raw',
@@ -61,14 +60,14 @@ validation_generator = validation_datagen.flow_from_dataframe(
 )
 
 
-print("Number of training samples: %d" % tf.data.experimental.cardinality(train_ds))
-print("Number of validation samples: %d" % tf.data.experimental.cardinality(validation_ds))
+# print("Number of training samples: %d" % tf.data.experimental.cardinality(train_ds))
+# print("Number of validation samples: %d" % tf.data.experimental.cardinality(validation_ds))
 
 
 
 
 # Build a model
-
+print("Start building the model")
 base_model = keras.applications.Xception(
     weights="imagenet",  # Load weights pre-trained on ImageNet.
     input_shape=(150, 150, 3),
@@ -81,15 +80,12 @@ base_model.trainable = False
 # Create new model on top
 inputs = keras.Input(shape=(150, 150, 3))
 
-# Pre-trained Xception weights requires that input be normalized
-# from (0, 255) to a range (-1., +1.), the normalization layer
-# does the following, outputs = (inputs - mean) / sqrt(var)
-norm_layer = keras.layers.experimental.preprocessing.Normalization()
-mean = np.array([127.5] * 3)
-var = mean ** 2
-# Scale inputs to [-1, +1]
-x = norm_layer(inputs)
-norm_layer.set_weights([mean, var])
+# Pre-trained Xception weights requires that input be scaled
+# from (0, 255) to a range of (-1., +1.), the rescaling layer
+# outputs: `(inputs * scale) + offset`
+scale_layer = keras.layers.Rescaling(scale=1 / 127.5, offset=-1)
+x = scale_layer(inputs)
+
 
 # The base model contains batchnorm layers. We want to keep them in inference mode
 # when we unfreeze the base model for fine-tuning, so we make sure that the
@@ -97,28 +93,35 @@ norm_layer.set_weights([mean, var])
 x = base_model(x, training=False)
 x = keras.layers.GlobalAveragePooling2D()(x)
 x = keras.layers.Dropout(0.2)(x)  # Regularize with dropout
-outputs = keras.layers.Dense(3, activation='sigmoid')(x)
+outputs = keras.layers.Dense(2, activation='sigmoid')(x)
 model = keras.Model(inputs, outputs)
 
 model.summary()
 
 
 # Train the top layer
-
+print("Start compiling the model")
 model.compile(
-    optimizer=keras.optimizers.Adam(),
+    optimizer=keras.optimizers.Nadam(),
     loss=keras.losses.BinaryCrossentropy(from_logits=False),
-    metrics=[[keras.metrics.BinaryAccuracy()],
-        [keras.metrics.BinaryAccuracy()],
-        [keras.metrics.BinaryAccuracy()]]
+    metrics=[keras.metrics.BinaryAccuracy(),
+        keras.metrics.FalseNegatives(),
+        keras.metrics.FalsePositives(),
+        keras.metrics.TrueNegatives(),
+        keras.metrics.TruePositives()
+    ]
 )
 
-epochs = 20
-model.fit(train_generator, epochs=epochs, validation_data=validation_generator)
+log_dir = "logs/fit/" + datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1)
+print("Start fitting the model")
+epochs = 25
+model.fit(train_generator, epochs=epochs, validation_data=validation_generator, 
+          callbacks=[tensorboard_callback])
 
 
 ## Save the model
-
+print("Start saving the model to disk")
 model.save(model_directory)
 
 print("Saved model to disk")

--- a/build_multi_hot_model.py
+++ b/build_multi_hot_model.py
@@ -3,6 +3,11 @@
 Build a multi-output Tensorflow model to predict whether symbols are visible.
 
 Names of columns with labels must end with `_visible`.
+
+Usage::
+
+    $ python build_multi_hot_model.py image_dir labels.csv output_model_dir
+
 """
 
 import tensorflow as tf

--- a/environment_m1.yml
+++ b/environment_m1.yml
@@ -4,8 +4,23 @@ channels:
   - apple
 dependencies:
   - python=3.8
+  - pandas
+  - numpy
+  - Pillow
   - apple::tensorflow-deps
   - pip
+  - cython
+  - libblas
+  - libcblas
+  - liblapack
+  - libcxx
+  - libffi
+  - libgfortran
+  - libgfortran5
+  - libopenblas
+  - llvm-openmp
+  - ncurses
+  - numexpr
   - pip:
       - tensorflow-macos
       - tensorflow-metal

--- a/eval_multi_hot_images.py
+++ b/eval_multi_hot_images.py
@@ -17,32 +17,60 @@ image_directory = pathlib.Path(sys.argv[2])
 metadata_path = sys.argv[3]
 results_path = sys.argv[4]
 
+print(f'Starting. Looking for images in {image_directory}, labels in {metadata_path}.')
+print(f'Loading the model from {model_directory}.')
 loaded_model = keras.models.load_model(model_directory)
 metadata = pd.read_csv(metadata_path)
 
+# Sample the metadata file to speed up the evaluation during development
+# metadata = metadata.sample(100, ignore_index=True)
+
+# Find the names of columns ending in '_visible'
+label_columns = [col_name for col_name in metadata.columns if col_name.endswith('_visible')]
+print(f'Found {label_columns} as columns with labels.')
+
 validation_datagen = keras.preprocessing.image.ImageDataGenerator(
     # rescale=1./255,
-    # validation_split=0.01
 )
 
 validation_generator = validation_datagen.flow_from_dataframe(
     dataframe=metadata,
     directory=image_directory,
     x_col='filename',
-    y_col=['pentagram_visible', 'star_visible'],
+    y_col=label_columns,
     weight_col=None,
     target_size=(150, 150),
     color_mode='rgb',
-    class_mode='raw',
+    class_mode='multi_output',
     shuffle=False,
-    # seed=42,
-    # subset='validation',
     interpolation='bilinear'
 )
 
+# Make the predictions
 predictions = loaded_model.predict(validation_generator, verbose=1)
-predictions_df = pd.DataFrame(predictions, columns=['pentagram_visible', 'star_visible'])
-results = metadata.join(predictions_df, rsuffix="_pred")
-results = results.assign(pentagram_correct=1 - abs(results.pentagram_visible - results.pentagram_visible_pred.round()),
-                         star_correct=1 - abs(results.star_visible - results.star_visible_pred.round()))
+
+# Convert predictions to a DataFrame
+pred_dict = {}
+for col_name, preds in zip(label_columns, predictions):
+    pred_dict[col_name.replace('_visible', '_pred')] = preds.ravel()
+predictions_df = pd.DataFrame(pred_dict)
+print(predictions_df.head())
+
+# Add columns with rounded prediction values
+rounded_pred_columns = [col + "_round" for col in predictions_df.columns]
+rounded_predictions = predictions_df.apply(round, axis=1)
+rounded_predictions.columns = rounded_pred_columns
+
+# Join the predictions with the original data
+results = metadata.join(predictions_df)
+results = results.join(rounded_predictions)
 results.to_csv(results_path, index=False)
+print(f'Saved the predictions to {results_path}.')
+
+print('Counting predictions for each combination of true and predicted label value.')
+confusions = results.groupby(label_columns + rounded_pred_columns)['filename']
+confusions_count = confusions.count()
+counts_path = results_path.replace('.csv', '_counts.csv')
+confusions_count.to_csv(counts_path)
+print(confusions_count)
+print(f'Saved these counts to {counts_path}.')

--- a/eval_multi_hot_images.py
+++ b/eval_multi_hot_images.py
@@ -1,0 +1,48 @@
+"""
+Evaluate a model's predictions on labeled data.
+"""
+import tensorflow as tf
+import numpy as np
+from tensorflow import keras
+from tensorflow.data import Dataset
+import os
+import sys
+import pandas as pd
+import pathlib
+
+
+# Load parameters
+model_directory = sys.argv[1]
+image_directory = pathlib.Path(sys.argv[2])
+metadata_path = sys.argv[3]
+results_path = sys.argv[4]
+
+loaded_model = keras.models.load_model(model_directory)
+metadata = pd.read_csv(metadata_path)
+
+validation_datagen = keras.preprocessing.image.ImageDataGenerator(
+    # rescale=1./255,
+    # validation_split=0.01
+)
+
+validation_generator = validation_datagen.flow_from_dataframe(
+    dataframe=metadata,
+    directory=image_directory,
+    x_col='filename',
+    y_col=['pentagram_visible', 'star_visible'],
+    weight_col=None,
+    target_size=(150, 150),
+    color_mode='rgb',
+    class_mode='raw',
+    shuffle=False,
+    # seed=42,
+    # subset='validation',
+    interpolation='bilinear'
+)
+
+predictions = loaded_model.predict(validation_generator, verbose=1)
+predictions_df = pd.DataFrame(predictions, columns=['pentagram_visible', 'star_visible'])
+results = metadata.join(predictions_df, rsuffix="_pred")
+results = results.assign(pentagram_correct=1 - abs(results.pentagram_visible - results.pentagram_visible_pred.round()),
+                         star_correct=1 - abs(results.star_visible - results.star_visible_pred.round()))
+results.to_csv(results_path, index=False)

--- a/eval_multi_hot_images.py
+++ b/eval_multi_hot_images.py
@@ -1,5 +1,10 @@
 """
 Evaluate a model's predictions on labeled data.
+
+Usage::
+
+    $ python eval_multi_hot_model.py model_dir image_dir labels.csv results.csv
+
 """
 import tensorflow as tf
 import numpy as np

--- a/predict_images.py
+++ b/predict_images.py
@@ -1,0 +1,74 @@
+"""
+Predict multiple labels for images in folders
+"""
+import tensorflow as tf
+import numpy as np
+from tensorflow import keras
+from tensorflow.data import Dataset
+import os
+import sys
+import pandas as pd
+import pathlib
+
+
+# Load parameters
+model_directory = sys.argv[1]
+images_path = pathlib.Path(sys.argv[2])
+results_path = sys.argv[3]
+
+print(f'Starting. Looking for images in {images_path}.')
+print(f'Loading the model from {model_directory}.')
+loaded_model = keras.models.load_model(model_directory)
+loaded_model.summary()
+
+
+filenames = Dataset.list_files(str(images_path/'*/*'), shuffle=False)
+
+
+img_height = 150
+img_width = 150
+
+
+def get_label(file_path):
+    # convert the path to a list of path components
+    parts = tf.strings.split(file_path, os.path.sep)
+    # The third to last is the class-directory
+    one_hot = parts[-3] == class_names
+    # Integer encode the label
+    return tf.argmax(one_hot)
+
+
+def decode_img(img):
+    # convert the compressed string to a 3D uint8 tensor
+    img = tf.io.decode_jpeg(img, channels=3)
+    # resize the image to the desired size
+    return tf.image.resize(img, [img_height, img_width])
+
+
+def process_path(file_path):
+    # label = get_label(file_path)
+    # load the raw data from the file as a string
+    img = tf.io.read_file(file_path)
+    img = tf.expand_dims( decode_img(img) , axis=0)
+    return img, file_path
+
+# Create Dataset of images from the filenames Dataset
+images_ds = filenames.map(process_path, num_parallel_calls=tf.data.AUTOTUNE, deterministic=True)
+
+# Create predictions using the loaded model
+predictions = loaded_model.predict(images_ds, verbose=1)
+# predictions is a list of ndarrays, one ndarray for each model output
+print("Length of predictions:", len(predictions))
+print("Shape of first item in predictions:", predictions[0].shape)
+print("Type of first item in predictions:", type(predictions[0]))
+# We don't need to convert the ndarrays to a dataset first,
+# we can load them into a DataFrame directly.
+# Load results into a DataFrame to save to CSV
+
+data = {"filename": filenames.as_numpy_iterator()}
+for c, p in zip(loaded_model.output_names, predictions):
+    data[c] = p.ravel() # flatten the prediction arrays
+
+results = pd.DataFrame(data)
+results.loc[:, "filename"] = results.loc[:, "filename"].str.decode('utf-8').str.replace(str(images_path), "")
+results.to_csv(results_path, index=False)

--- a/predict_images.py
+++ b/predict_images.py
@@ -27,7 +27,7 @@ loaded_model = keras.models.load_model(model_directory)
 loaded_model.summary()
 
 
-filenames = Dataset.list_files(str(images_path/'*/*'), shuffle=False)
+filenames = Dataset.list_files(str(images_path/'*/*/*.jpg'), shuffle=False)#.take(100)
 
 
 img_height = 150
@@ -58,7 +58,7 @@ def process_path(file_path):
     return img, file_path
 
 # Create Dataset of images from the filenames Dataset
-images_ds = filenames.map(process_path, num_parallel_calls=tf.data.AUTOTUNE, deterministic=True)
+images_ds = filenames.map(process_path, num_parallel_calls=None, deterministic=True).prefetch(2)
 
 # Create predictions using the loaded model
 predictions = loaded_model.predict(images_ds, verbose=1)

--- a/predict_images.py
+++ b/predict_images.py
@@ -1,5 +1,10 @@
 """
 Predict multiple labels for images in folders
+
+Usage::
+
+    $ python predict_images.py model_dir image_dir predictions.csv
+
 """
 import tensorflow as tf
 import numpy as np

--- a/predict_images_from_frame.py
+++ b/predict_images_from_frame.py
@@ -1,0 +1,83 @@
+"""
+Create predictions on files listed in a dataframe.
+
+Usage::
+
+    $ python predict_images_from_frame.py model_dir image_dir file_list.csv results.csv
+
+"""
+import tensorflow as tf
+import numpy as np
+from tensorflow import keras
+
+import os
+import sys
+import pandas as pd
+import pathlib
+
+
+# Load parameters
+model_directory = sys.argv[1]
+image_directory = pathlib.Path(sys.argv[2])
+metadata_path = sys.argv[3]
+results_path = sys.argv[4]
+
+print(f'Starting. Looking for images in {image_directory}, labels in {metadata_path}.')
+print(f'Loading the model from {model_directory}.')
+loaded_model = keras.models.load_model(model_directory)
+metadata = pd.read_csv(metadata_path)
+
+# Sample the metadata file to speed up the evaluation during development
+# metadata = metadata.sample(100, ignore_index=True)
+
+# Find the names of columns ending in '_visible'
+label_columns = [col_name for col_name in metadata.columns if col_name.endswith('_visible')]
+print(f'Found {label_columns} as columns with labels.')
+
+validation_datagen = keras.preprocessing.image.ImageDataGenerator(
+    # rescale=1./255,
+)
+
+validation_generator = validation_datagen.flow_from_dataframe(
+    dataframe=metadata,
+    directory=image_directory,
+    x_col='filename',
+    y_col=label_columns,
+    weight_col=None,
+    target_size=(150, 150),
+    color_mode='rgb',
+    class_mode='multi_output',
+    shuffle=False,
+    interpolation='bilinear'
+)
+# print(validation_generator.filenames, type(validation_generator.filenames), len(validation_generator.filenames))
+# sys.exit(0)
+# Make the predictions
+predictions = loaded_model.predict(validation_generator, verbose=1)
+
+# Convert predictions to a DataFrame
+pred_dict = {}
+for col_name, preds in zip(label_columns, predictions):
+    pred_dict[col_name.replace('_visible', '_pred')] = preds.ravel()
+pred_dict['filename'] = validation_generator.filenames
+predictions_df = pd.DataFrame(pred_dict)
+print(predictions_df.head())
+
+# Add columns with rounded prediction values
+rounded_pred_columns = [col + "_round" for col in predictions_df.columns]
+rounded_predictions = predictions_df.apply(round, axis=1)
+rounded_predictions.columns = rounded_pred_columns
+
+# Join the predictions with the original data
+results = pd.merge(metadata, predictions_df, on='filename')
+results = results.join(rounded_predictions)
+results.to_csv(results_path, index=False)
+print(f'Saved the predictions to {results_path}.')
+
+print('Counting predictions for each combination of predicted label value.')
+totals = results.groupby(rounded_pred_columns)['filename']
+totals_count = totals.size()
+counts_path = results_path.replace('.csv', '_counts.csv')
+totals_count.to_csv(counts_path)
+print(totals_count)
+print(f'Saved these counts to {counts_path}.')

--- a/predict_images_from_frame.py
+++ b/predict_images_from_frame.py
@@ -59,7 +59,6 @@ predictions = loaded_model.predict(validation_generator, verbose=1)
 pred_dict = {}
 for col_name, preds in zip(label_columns, predictions):
     pred_dict[col_name.replace('_visible', '_pred')] = preds.ravel()
-pred_dict['filename'] = validation_generator.filenames
 predictions_df = pd.DataFrame(pred_dict)
 print(predictions_df.head())
 
@@ -67,6 +66,9 @@ print(predictions_df.head())
 rounded_pred_columns = [col + "_round" for col in predictions_df.columns]
 rounded_predictions = predictions_df.apply(round, axis=1)
 rounded_predictions.columns = rounded_pred_columns
+
+# Add filenames to DataFrame
+predictions_df.loc[:, 'filename'] = pd.Series(validation_generator.filenames)
 
 # Join the predictions with the original data
 results = pd.merge(metadata, predictions_df, on='filename')


### PR DESCRIPTION
This closes #6 and closes #7.

`build_multi_hot_model.py` trains a multi-output model from a CSV file with at least one column whose name ends with `_visible` to (hopefully) recognise symbols.

`evaluate_multi_hot_model.py` uses similary structured CSV files to evaluate such models. It saves the confusions to a CSV file.

`predict_images.py` uses a model to make predictions for all images in subdirectories of a given directory and saves the predictions to a CSV file.

I had to update the conda environment file to make the installation work.